### PR TITLE
Require Go 1.24.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jart/gosip
 
-go 1.14
+go 1.24


### PR DESCRIPTION
The library currently declares a dependency on Go 1.14, which hasn't been supported for over four years now.  Obviously, nobody is testing against Go 1.14, and there are quite a few nice features that Go has acquired over the last years.

This PR makes the library require Go 1.24, which is the version currently in Debian Stable.  If that is too recent for some people, we could make this Go 1.21, which has most of the nice features. (The oldest version I can comfortably work with is Go 1.17.)

@jart, okay with you?
